### PR TITLE
feat: migrate fish classification  to LanceDB 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ ndarray = "0.15.6"
 ndarray-npy = "0.8.1"
 opencv = { version = "0.91.3", features = ["clang-runtime"] }
 ort = { git = "https://github.com/pykeio/ort.git", version = "2.0.0-rc.2", tag = "v2.0.0-rc.2" }
-reqwest = { version = "0.12.4", features = ["blocking"] }
+reqwest = { version = "0.12.4", features = ["blocking", "json"] }
 ndarray-stats = { git = "https://github.com/ccrutchf/ndarray-stats.git", version = "0.5.1" }
 faer = "0.18.2"
 num = "0.4.3"
@@ -27,5 +27,13 @@ imageproc = "0.25"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
+lancedb = "0.21.0"
+tokio = { version = "1.38.0", features = ["full"] }
+futures = "0.3"
+arrow-array = "55.0"
+arrow-schema = "55.0"
+
+
 
 [dev-dependencies]
+tokio-test = "0.4"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FishSense
 
-**FishSense** is a Rust toolkit for analyzing fish images using machine learning and image processing. It classifies species, segments fish from backgrounds, detects head/tail points, and estimates fish length using depth data.
+**FishSense** is a Rust toolkit for analyzing fish images using machine learning and image processing. It classifies species, segments fish from backgrounds, detects head/tail points, and estimates fish length using depth data. The system features a vector database architecture optimized for edge deployment and real-time classification.
 
 ---
 
@@ -10,6 +10,7 @@
 - **Segmentation**: Extracts precise fish masks from images.
 - **Head/Tail Detection**: Locates points using fish geometry and PCA.
 - **3D Length Estimation**: Computes real-world fish length using image coordinates, depth maps, and camera intrinsics.
+- **Vector Database**: Similarity search across 69,990+ species embeddings using LanceDB.
 
 ---
 
@@ -17,13 +18,15 @@
 
 ### Root
 
-- `Cargo.toml`: Rust manifest. Key crates: `ort`, `opencv`, `image`, `ndarray`, `faer`, `serde`, `anyhow`, `reqwest`.
+- `Cargo.toml`: Rust manifest. Key crates: `ort`, `opencv`, `image`, `ndarray`, `faer`, `serde`, `anyhow`, `reqwest`, `lancedb`, `arrow-array`, `tokio`. 
 - `rust-toolchain.toml`: Pins the Rust version.
 
 ### `src/`
 
-- `main.rs`: CLI for running classification on a fish image.
+- `main_old.rs`: Original manual CLI for running classification on a fish image.
+- `main.rs`: Vector database-powered CLI for fish classification on a fish image.
 - `lib.rs`: Exposes library modules.
+- `migrate.rs`: Automated migration system for embedding database setup.
 
 #### Core Modules
 
@@ -37,11 +40,13 @@
 - `fish_segmentation.rs`: Runs ONNX instance segmentation model; outputs binary masks and contours.
 - `autolabel.rs`: Detects head/tail points using convex hull analysis.
 - `fish_length_calculator.rs`: Snaps head/tail to best depth values; computes length.
+- `vector_db_classifier.rs`: LanceDB-powered classifier with normalized embeddings and cosine similarity.
 
 ---
 
 ## `data/` Directory
 
+fish_lancedb/: Vector database containing normalized embeddings and species metadata.
 Test files: sample fish images, segmentation masks, `.npz` arrays, etc. Used in module tests. 
 
 ---
@@ -67,6 +72,19 @@ git clone <repo-url>
 cd fishsense
 cargo build             # dev build
 cargo build --release   # optimized build
+
+
+
+```
+
+### Usage
+
+```bash
+- On first execution, the system will automatically:
+
+- Download the ONNX model and embedding data
+- Create the vector database with normalized embeddings
+- Build search indexes 
 
 
 ```

--- a/src/fish/fish_vectordb_classifier.rs
+++ b/src/fish/fish_vectordb_classifier.rs
@@ -1,0 +1,242 @@
+use app_dirs2::{app_root, AppDataType, AppInfo};
+use anyhow::{Context, Result};
+use ndarray::{Array1, Array2, Array3, Axis};
+use ort::Session;
+use reqwest::blocking::get;
+use std::fs::{create_dir_all, File};
+use std::io::copy;
+use std::path::PathBuf;
+use std::time::Instant;
+use std::collections::HashMap;
+use serde::Deserialize;
+use serde_json::Value;
+
+// LanceDB imports
+use lancedb::{connect, Connection, Table};
+use arrow_array::{StringArray, Float32Array, UInt32Array};
+use futures::TryStreamExt;
+use lancedb::query::{QueryBase, ExecutableQuery};
+use lancedb::DistanceType;
+
+const MODEL_URL: &str = "https://huggingface.co/unushri/onnx-fish-classifier/resolve/main/fish_classifier.onnx?download=true";
+const METADATA_URL: &str = "https://huggingface.co/unushri/onnx-fish-classifier/resolve/main/database.json?download=true";
+
+#[derive(Debug, Deserialize)]
+pub struct Metadata {
+    pub internal_ids: Vec<usize>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub image_ids: Vec<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub annotation_ids: Vec<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub drawn_fish_ids: Vec<u32>,
+    pub keys: HashMap<String, serde_json::Value>,
+}
+
+pub struct VectorDbFishClassifier {
+    model: Session,
+    fish_table: Table,
+}
+
+impl VectorDbFishClassifier {
+    pub async fn new() -> Result<Self> {
+        let model_path = Self::download_file("fish_classifier.onnx", MODEL_URL)?;
+        let model = Session::builder()?.commit_from_file(&model_path)?;
+        
+        println!("Model loaded successfully");
+        println!("Model inputs:");
+        for inp in &model.inputs {
+            println!("- Name: {}, Type: {:?}", inp.name, inp.input_type);
+        }
+        
+        let uri = "data/fish_lancedb";
+        let db = connect(uri).execute().await?;
+        
+        let fish_table = db.open_table("fish_embeddings").execute().await
+            .context("Failed to open fish_embeddings table. Run migration first!")?;
+        
+        let species_count = fish_table.count_rows(None).await?;
+        println!("Connected to database with {} embeddings", species_count);
+        
+        Ok(VectorDbFishClassifier {
+            model,
+            fish_table,
+        })
+    }
+
+    fn download_file(filename: &str, url: &str) -> Result<PathBuf> {
+        let mut path = app_root(
+            AppDataType::UserCache,
+            &AppInfo {
+                name: "fish-classifier",
+                author: "unushri",
+            },
+        )?;
+        path.push("models");
+        create_dir_all(&path)?;
+        path.push(filename);
+        
+        if !path.exists() {
+            println!("Downloading {}...", filename);
+            let mut resp = get(url)?;
+            let mut out = File::create(&path)?;
+            copy(&mut resp, &mut out)?;
+        }
+        
+        Ok(path)
+    }
+
+    pub async fn classify(&self, input_tensor: Array3<f32>) -> Result<Vec<(String, f32)>> {
+        // Run ONNX model to get embedding
+        let batched = input_tensor.insert_axis(Axis(0));
+        let input_name = self.model.inputs[0].name.clone();
+        
+        let input_tensor = ort::Value::from_array(batched.view())?;
+        let inputs: Vec<(String, ort::SessionInputValue)> = vec![
+            (input_name, ort::SessionInputValue::from(input_tensor))
+        ];
+
+        let outputs = self.model.run(inputs)?;
+
+        let embedding: Array2<f32> = outputs[0]
+            .try_extract_tensor::<f32>()?
+            .into_dimensionality()
+            .context("Embedding shape conversion failed")?
+            .to_owned();
+
+        let logits: Array2<f32> = outputs[1]
+            .try_extract_tensor::<f32>()?
+            .into_dimensionality()
+            .context("Logits shape conversion failed")?
+            .to_owned();
+
+        // Get direct classification from logits for comparison
+        let class_idx = logits
+            .row(0)
+            .iter()
+            .cloned()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+            .map(|(i, _)| i)
+            .unwrap_or(0);
+
+        let predicted_class_name = self.get_class_name_from_logits(class_idx).await?;
+        println!("Direct prediction: {}", predicted_class_name);
+
+        // Use vector database search for top-k results
+        let embed_vec = embedding.row(0).to_owned();
+        let top_matches = self.vector_search(embed_vec, 5).await?;
+        
+        Ok(top_matches)
+    }
+
+    async fn get_class_name_from_logits(&self, class_idx: usize) -> Result<String> {
+        let meta_path = Self::download_file("database.json", METADATA_URL)?;
+        let metadata_content = std::fs::read_to_string(&meta_path)?;
+        let json: Value = serde_json::from_str(&metadata_content)?;
+        
+        if let Some(keys) = json.get("keys").and_then(|k| k.as_object()) {
+            if let Some(value) = keys.get(&class_idx.to_string()) {
+                if let Some(label) = value.get("label").and_then(|l| l.as_str()) {
+                    return Ok(label.to_string());
+                }
+            }
+        }
+        
+        Ok(format!("unknown_class_{}", class_idx))
+    }
+
+    async fn vector_search(&self, query_embedding: Array1<f32>, k: usize) -> Result<Vec<(String, f32)>> {
+        let query_vector: Vec<f32> = query_embedding.to_vec();
+        
+        // Normalize the query vector for proper cosine distance
+        let norm: f32 = query_vector.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let normalized_query = if norm > 0.0 {
+            query_vector.iter().map(|x| x / norm).collect::<Vec<f32>>()
+        } else {
+            query_vector
+        };
+        
+        let start = Instant::now();
+        
+        let mut results = self.fish_table
+            .query()
+            .nearest_to(normalized_query)?
+            .distance_type(DistanceType::Cosine)
+            .limit(k)
+            .execute()
+            .await?;
+        
+        let search_time = start.elapsed();
+        
+        let mut fish_matches = Vec::new();
+        
+        while let Some(batch) = results.try_next().await? {
+            let distances = batch
+                .column_by_name("_distance")
+                .context("Missing _distance column from LanceDB results")?
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .context("Failed to cast _distance column")?;
+                
+            let species_names = batch
+                .column_by_name("species_name")
+                .context("Missing species_name column")?
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .context("Failed to cast species_name column")?;
+            
+            let class_ids = batch
+                .column_by_name("class_id")
+                .context("Missing class_id column")?
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .context("Failed to cast class_id column")?;
+            
+            for i in 0..batch.num_rows() {
+                let distance = distances.value(i);
+                let species_name = species_names.value(i).to_string();
+                let class_id = class_ids.value(i);
+                
+                // Convert cosine distance to confidence score
+                let confidence = (1.0 - (distance / 2.0)).clamp(0.0, 1.0);
+                
+                fish_matches.push((species_name, confidence));
+                
+                if i == 0 {
+                    println!("Top match: {} (class_id: {}, distance: {:.4}, confidence: {:.3})", 
+                             species_names.value(i), class_id, distance, confidence);
+                }
+            }
+        }
+        
+        println!("Vector search completed in {:?}", search_time);
+        
+        Ok(fish_matches)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array3;
+
+    #[tokio::test]
+    async fn test_vector_db_fish_classifier() {
+        let classifier = VectorDbFishClassifier::new().await.expect("Failed to create classifier");
+        let dummy_input = Array3::<f32>::zeros((3, 224, 224));
+    
+        let result = classifier.classify(dummy_input).await.expect("Classification failed");
+
+        println!("Classification results: {:?}", result);
+        assert!(!result.is_empty(), "Should return at least one result");
+        
+        for (_, confidence) in &result {
+            assert!(confidence >= &0.0 && confidence <= &1.0, 
+                   "Confidence score should be between 0 and 1, got {}", confidence);
+        }
+    }
+}

--- a/src/fish/mod.rs
+++ b/src/fish/mod.rs
@@ -1,10 +1,11 @@
 mod fish_segmentation;
 mod fish_length_calculator;
 mod fish_classifier;
+mod fish_vectordb_classifier;
 mod autolabel;
-
 
 pub use fish_segmentation::{FishSegmentation, SegmentationError};
 pub use fish_length_calculator::FishLengthCalculator;
-pub use fish_classifier:: {FishClassifier};
+pub use fish_classifier::FishClassifier;
+pub use fish_vectordb_classifier::VectorDbFishClassifier;
 pub use autolabel::{FishHeadTailDetector, HeadTailError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,5 @@ pub mod world_point_handler;
 pub use world_point_handler::WorldPointHandler;
 
 mod linalg;
+
+pub mod migrate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,39 @@
-use fishsense:: fish :: FishClassifier;
 use image::GenericImageView;
 use ndarray::Array3;
 use std::env;
 use std::path::Path;
+use std::time::Instant;
+use anyhow::Result;
+use lancedb::connect;
+use fishsense::fish::VectorDbFishClassifier;
 
-fn main() -> anyhow::Result<()> {
+mod migrate;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("FishSense Vector Database Classification System");
+    println!("Process ID: {}", std::process::id());
+    
+    let uri = "data/fish_lancedb"; 
+    let db = connect(uri).execute().await?;
+    
+    // Check if migration is needed
+    match db.open_table("fish_embeddings").execute().await {
+        Ok(table) => {
+            let count = table.count_rows(None).await?;
+            if count > 0 {
+                println!("Database ready with {} embeddings", count);
+            } else {
+                println!("Database exists but empty, running migration...");
+                migrate::run_migration().await?;
+            }
+        },
+        Err(_) => {
+            println!("Database not found, running migration...");
+            migrate::run_migration().await?;
+        }
+    }
+    
     // Get image path from command-line args
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
@@ -12,31 +41,47 @@ fn main() -> anyhow::Result<()> {
         std::process::exit(1);
     }
     let image_path = &args[1];
+    
+    // Initialize classifier
+    let init_start = Instant::now();
+    let classifier = VectorDbFishClassifier::new().await?;
+    let init_time = init_start.elapsed();
+    
+    // Load and process image
+    let array = load_and_process_image(image_path)?;
+    
+    // Run classification
+    let classify_start = Instant::now();
+    let predictions = classifier.classify(array).await?;
+    let classify_time = classify_start.elapsed();
+    
+    // Print results
+    println!("\nFish Classification Results:");
+    for (label, score) in predictions {
+        println!("{} ({:.3})", label, score);
+    }
+    
+    println!("\nPerformance:");
+    println!("Initialization: {:?}", init_time);
+    println!("Classification: {:?}", classify_time);
+    println!("Total: {:?}", init_time + classify_time);
+    
+    Ok(())
+}
 
-    // Load the image
-    let img = image::open(&Path::new(image_path))
-        .expect("Failed to open image")
+fn load_and_process_image(image_path: &str) -> Result<Array3<f32>> {
+    let img = image::open(&Path::new(image_path))?
         .resize_exact(224, 224, image::imageops::FilterType::Nearest);
-
-    // Convert image to RGB and ndarray::Array3<f32>
+    
     let rgb = img.to_rgb8();
     let (width, height) = rgb.dimensions();
     let mut array = Array3::<f32>::zeros((3, height as usize, width as usize));
+    
     for (x, y, pixel) in rgb.enumerate_pixels() {
         array[[0, y as usize, x as usize]] = pixel[2] as f32 / 255.0;
         array[[1, y as usize, x as usize]] = pixel[1] as f32 / 255.0;
         array[[2, y as usize, x as usize]] = pixel[0] as f32 / 255.0;
     }
-
-    // Run classifier
-    let classifier = FishClassifier::new()?;
-    let predictions = classifier.classify(array)?;
-
-    // Print results
-    println!("\n Fish Classification Results:");
-    for (label, score) in predictions {
-        println!("{} ({:.2})", label, score);
-    }
-
-    Ok(())
+    
+    Ok(array)
 }

--- a/src/main_old.rs
+++ b/src/main_old.rs
@@ -1,0 +1,42 @@
+use fishsense:: fish :: FishClassifier;
+use image::GenericImageView;
+use ndarray::Array3;
+use std::env;
+use std::path::Path;
+
+fn main() -> anyhow::Result<()> {
+    // Get image path from command-line args
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: cargo run --release -- path/to/image.jpg");
+        std::process::exit(1);
+    }
+    let image_path = &args[1];
+
+    // Load the image
+    let img = image::open(&Path::new(image_path))
+        .expect("Failed to open image")
+        .resize_exact(224, 224, image::imageops::FilterType::Nearest);
+
+    // Convert image to RGB and ndarray::Array3<f32>
+    let rgb = img.to_rgb8();
+    let (width, height) = rgb.dimensions();
+    let mut array = Array3::<f32>::zeros((3, height as usize, width as usize));
+    for (x, y, pixel) in rgb.enumerate_pixels() {
+        array[[0, y as usize, x as usize]] = pixel[2] as f32 / 255.0;
+        array[[1, y as usize, x as usize]] = pixel[1] as f32 / 255.0;
+        array[[2, y as usize, x as usize]] = pixel[0] as f32 / 255.0;
+    }
+
+    // Run classifier
+    let classifier = FishClassifier::new()?;
+    let predictions = classifier.classify(array)?;
+
+    // Print results
+    println!("\n Fish Classification Results:");
+    for (label, score) in predictions {
+        println!("{} ({:.2})", label, score);
+    }
+
+    Ok(())
+}

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,0 +1,200 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use anyhow::Result;
+use lancedb::{connect, Connection};
+use serde_json::Value;
+use arrow_array::{
+    Float32Array, StringArray, UInt32Array, FixedSizeListArray,
+    RecordBatch, RecordBatchIterator
+};
+use arrow_schema::{DataType, Field, Schema};
+use arrow_array::types::Float32Type;
+
+const EMBEDDING_URL: &str = "https://huggingface.co/unushri/onnx-fish-classifier/resolve/main/embeddings.npy?download=true";
+const METADATA_URL: &str = "https://huggingface.co/unushri/onnx-fish-classifier/resolve/main/database.json?download=true";
+
+pub async fn run_migration() -> Result<()> {
+    let uri = "data/fish_lancedb";
+    let db = connect(uri).execute().await?;
+    
+    // Check if table exists and has data
+    match db.open_table("fish_embeddings").execute().await {
+        Ok(table) => {
+            let count = table.count_rows(None).await?;
+            if count > 0 {
+                println!("Database already exists with {} embeddings", count);
+                return Ok(());
+            }
+        }
+        Err(_) => {}
+    }
+    
+    // Download files if needed
+    if !Path::new("embeddings.npy").exists() {
+        println!("Downloading embeddings...");
+        download_file(EMBEDDING_URL, "embeddings.npy").await?;
+    }
+    
+    if !Path::new("database.json").exists() {
+        println!("Downloading metadata...");
+        download_file(METADATA_URL, "database.json").await?;
+    }
+    
+    // Load the fish data
+    println!("Loading embeddings and metadata...");
+    let embeddings = load_fish_embeddings()?;
+    let metadata = load_fish_metadata()?;
+    
+    println!("Loaded {} embeddings and {} species classes", 
+             embeddings.len(), metadata.keys.len());
+    
+    // Create the fish vector database
+    create_fish_database(&db, &embeddings, &metadata).await?;
+    
+    println!("Migration completed successfully");
+    Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct FishMetadata {
+    internal_ids: Vec<usize>,
+    keys: HashMap<String, serde_json::Value>,
+}
+
+fn load_fish_embeddings() -> Result<Vec<Vec<f32>>> {
+    use ndarray::Array2;
+    use ndarray_npy::read_npy;
+    
+    let embeddings: Array2<f32> = read_npy("embeddings.npy")?;
+    println!("Embedding shape: {:?}", embeddings.dim());
+    Ok(embeddings.outer_iter().map(|row| row.to_vec()).collect())
+}
+
+fn load_fish_metadata() -> Result<FishMetadata> {
+    let content = std::fs::read_to_string("database.json")?;
+    let metadata: FishMetadata = serde_json::from_str(&content)?;
+    Ok(metadata)
+}
+
+async fn create_fish_database(
+    db: &Connection,
+    embeddings: &[Vec<f32>],
+    metadata: &FishMetadata,
+) -> Result<()> {
+    
+    let vector_dim = embeddings.get(0).map(|e| e.len()).unwrap_or(512) as i32;
+    println!("Vector dimension: {}", vector_dim);
+    
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("embedding_id", DataType::UInt32, false),
+        Field::new("class_id", DataType::UInt32, false),
+        Field::new("species_name", DataType::Utf8, false),
+        Field::new("species_id", DataType::Utf8, false),
+        Field::new(
+            "embedding", 
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)), 
+                vector_dim
+            ), 
+            false
+        ),
+    ]));
+    
+    let mut embedding_ids = Vec::new();
+    let mut class_ids = Vec::new();
+    let mut species_names = Vec::new();
+    let mut species_ids = Vec::new();
+    let mut fish_embeddings = Vec::new();
+    
+    // Use the original mapping from internal_ids and normalize vectors
+    for (embedding_idx, embedding) in embeddings.iter().enumerate() {
+        // Get the class ID for this embedding from internal_ids
+        let class_id = if embedding_idx < metadata.internal_ids.len() {
+            metadata.internal_ids[embedding_idx] as u32
+        } else {
+            continue;
+        };
+        
+        // Normalize the embedding vector for proper cosine distance
+        let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let normalized_embedding = if norm > 0.0 {
+            embedding.iter().map(|x| x / norm).collect::<Vec<f32>>()
+        } else {
+            embedding.clone()
+        };
+        
+        // Look up species info from keys using class_id
+        if let Some(class_info) = metadata.keys.get(&class_id.to_string()) {
+            let species_name = class_info
+                .get("label")
+                .and_then(|l| l.as_str())
+                .unwrap_or("Unknown Species")
+                .to_string();
+            
+            let species_uuid = class_info
+                .get("species_id")
+                .and_then(|s| s.as_str())
+                .unwrap_or("unknown-uuid")
+                .to_string();
+            
+            embedding_ids.push(embedding_idx as u32);
+            class_ids.push(class_id);
+            species_names.push(species_name);
+            species_ids.push(species_uuid);
+            fish_embeddings.push(Some(normalized_embedding));
+        }
+    }
+    
+    println!("Processed {} valid embeddings", embedding_ids.len());
+    
+    let vector_array = Arc::new(
+        FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
+            fish_embeddings.into_iter().map(|opt_vec| {
+                opt_vec.map(|vec| vec.into_iter().map(Some).collect::<Vec<Option<f32>>>())
+            }),
+            vector_dim,
+        ),
+    );
+    
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(UInt32Array::from(embedding_ids)),
+            Arc::new(UInt32Array::from(class_ids)),
+            Arc::new(StringArray::from(species_names)),
+            Arc::new(StringArray::from(species_ids)),
+            vector_array,
+        ],
+    )?;
+    
+    let batches = RecordBatchIterator::new(
+        vec![batch].into_iter().map(Ok),
+        schema.clone(),
+    );
+    
+    println!("Creating table and index...");
+    let table = db
+        .create_table("fish_embeddings", Box::new(batches))
+        .execute()
+        .await?;
+    
+    // Create vector index for fast similarity search
+    match table.create_index(&["embedding"], lancedb::index::Index::Auto).execute().await {
+        Ok(_) => println!("Vector index created"),
+        Err(e) => println!("Index creation failed (table still usable): {}", e),
+    }
+    
+    // Verify the migration
+    let count = table.count_rows(None).await?;
+    println!("Database created with {} embeddings ready for search", count);
+    
+    Ok(())
+}
+
+async fn download_file(url: &str, path: &str) -> Result<()> {
+    let response = reqwest::get(url).await?;
+    let bytes = response.bytes().await?;
+    std::fs::write(path, bytes)?;
+    Ok(())
+}


### PR DESCRIPTION

 Workflow
- One-time setup: Convert embeddings.npy and database.json into LanceDB format
- Classification: Query normalized embedding against indexed vector database
- LanceDB handles similarity search using HNSW algorithm with cosine distance

Implementation
- Vector normalization: All embeddings converted to unit vectors for proper cosine distance
- Database schema: embedding_id, class_id, species_name, species_id, normalized_embedding
- Migration preserves original internal_ids mapping to maintain classification consistency
- Distance-to-confidence conversion: confidence = 1.0 - (cosine_distance / 2.0)

Compatibility with Old DB
- Preserved original manual implementation as main_old.rs and fish_classifier.rs
- Identical API: Vec<(String, f32)> return format maintained
- Same confidence score ranges and species mapping
- Switching between implementations for validation

